### PR TITLE
Fix #18: proxy the touchpad instead of grabbing mid-gesture (fixes KDE 3-finger desktop-switch conflict)

### DIFF
--- a/src/init/libinput_init.rs
+++ b/src/init/libinput_init.rs
@@ -4,9 +4,9 @@ use std::fs::{File, OpenOptions};
 use std::os::unix::{fs::OpenOptionsExt, io::OwnedFd};
 use std::path::Path;
 use input::{
-    Libinput, 
-    LibinputInterface, 
-    event::EventTrait, 
+    Libinput,
+    LibinputInterface,
+    event::EventTrait,
     DeviceCapability::{Gesture, Pointer}
 };
 use tracing::{debug, info, error};
@@ -31,71 +31,31 @@ impl LibinputInterface for Interface {
 }
 
 
-/// Add devices to `Libinput` struct. 
-fn bind_to_real_trackpads(trackpads: Vec<input::Device>) -> Result<Libinput, Error> {
+/// Produce the correct error and logs to pinpoint the cause of the issue.
+fn raise_correct_error(devices_added: u8) -> std::io::Error {
 
-    let mut real_trackpads = Libinput::new_from_path(Interface);
-
-    for tp_dev in trackpads {
-        
-        match real_trackpads.path_add_device(&format!("/dev/input/{}", tp_dev.sysname())) {
-
-            Some(real_dev) => {
-                info!("A touchpad found and loaded.");
-                debug!("The touchpad device found: \"{}\" (udev path: /dev/input/{}).", 
-                    real_dev.name(), real_dev.sysname()
-                );
-            },
-            None => {
-                error!("Could not load the touchpad device \
-                    at `/dev/input/{}`. It may also be a permissions \
-                    error, but the underlying crate (input.rs) does not raise \
-                    errors when a device cannot be loaded, so it's unclear. \
-                    Please submit a Github issue at https://github.com/lmr97/linux-3-finger-drag/issues \
-                    whether you sort this out or not, so as to help others in the \
-                    same situation, and help me develop a better program. Thank \
-                    you for trying it out",
-                    tp_dev.sysname()
-                );
-                return Err(
-                    Error::new(
-                        ErrorKind::AddrNotAvailable, 
-                        "trackpad found, could not bind"
-                    )
-                )
-            }
-        }
-    }
-
-    Ok(real_trackpads)
-}
-
-
-/// Produce the correct error and logs to pinpoint the cause of the issue. 
-fn raise_correct_error(devices_added: u8) -> Result<Libinput, std::io::Error> {
-
-    // Since the `input` crate does not give any errors from 
-    // udev_assign_seat() even on failure, we've gotta figure 
-    // it out ourselves! This will not return `Ok(Libinput)` in any
-    // control path; the return type is chosen only for compatibility
-    // with its caller, `find_real_trackpad()`.
+    // Since the `input` crate does not give any errors from
+    // udev_assign_seat() even on failure, we've gotta figure
+    // it out ourselves! This always returns an `Err`; the return
+    // type is chosen only for compatibility with its caller,
+    // `find_real_trackpad()`.
     //
-    // 
+    //
     // There are two possible error conditions for this match arm:
-    // 
+    //
     //    1. Insufficient permissions to access /dev/input
     //
-    //    2. The device does not have a "trackpad" or "touchpad" 
+    //    2. The device does not have a "trackpad" or "touchpad"
     //       in the name given by libinput
-    // 
+    //
     // Here is how I am checking for each condition:
-    // 
+    //
     //    1. Permissions -- If one of the following is true:
-    //       a. The program found 0 libinput events at all 
+    //       a. The program found 0 libinput events at all
     //       b. The user is not in the 'input' group
-    // 
-    //    2. Not found -- no conditions from (1.) are satisfied. 
-    //       This is a bug (if there's actually a trackpad), and 
+    //
+    //    2. Not found -- no conditions from (1.) are satisfied.
+    //       This is a bug (if there's actually a trackpad), and
     //       warrants an issue being opened on GitHub.
 
 
@@ -106,11 +66,9 @@ fn raise_correct_error(devices_added: u8) -> Result<Libinput, std::io::Error> {
         None => {
             error!("The user that started this program (somehow) has been removed from \
                 the user database! Something strange is afoot. Exiting...");
-            return Err(
-                Error::new(
-                    ErrorKind::PermissionDenied, 
-                    "user who started the process no longer exists"
-                )
+            return Error::new(
+                ErrorKind::PermissionDenied,
+                "user who started the process no longer exists"
             );
         }
     };
@@ -124,11 +82,9 @@ fn raise_correct_error(devices_added: u8) -> Result<Libinput, std::io::Error> {
         None => {
             error!("You are, somehow, not a part of any user groups. \
                 Something strange is afoot. Exiting...");
-            return Err(
-                Error::new(
-                    ErrorKind::PermissionDenied, 
-                    "user is not in any user groups whatsoever"
-                )
+            return Error::new(
+                ErrorKind::PermissionDenied,
+                "user is not in any user groups whatsoever"
             );
         }
     };
@@ -139,7 +95,7 @@ fn raise_correct_error(devices_added: u8) -> Result<Libinput, std::io::Error> {
         .iter()
         .find(|group| group.name() == "input")
         .is_some();
-        
+
 
     if devices_added == 0 || !in_input_group {
         error!("This program does not have permission to access \
@@ -154,10 +110,8 @@ fn raise_correct_error(devices_added: u8) -> Result<Libinput, std::io::Error> {
             look into it as soon as possible."
         );
 
-        return Err(
-            Error::new(ErrorKind::PermissionDenied,
-                "not in user group 'input'"
-            )
+        return Error::new(ErrorKind::PermissionDenied,
+            "not in user group 'input'"
         );
     }
 
@@ -170,34 +124,32 @@ fn raise_correct_error(devices_added: u8) -> Result<Libinput, std::io::Error> {
         devices_added
     );
 
-    Err(
-        Error::new(
-            ErrorKind::PermissionDenied, 
-            "trackpad not discoverable by current user"
-        )
+    Error::new(
+        ErrorKind::PermissionDenied,
+        "trackpad not discoverable by current user"
     )
 }
 
 
-/// Find all devices that function as trackpads, returning
-/// a `Libinput` struct that will receive events from all
-/// trackpads.
-pub fn find_real_trackpads() -> Result<Libinput, std::io::Error> {
+/// Find all devices that function as trackpads, returning the `/dev/input/eventN`
+/// paths for each. The caller is responsible for opening these directly (not
+/// through libinput) so it can exclusively grab and proxy the raw event stream.
+pub fn find_real_trackpads() -> Result<Vec<String>, std::io::Error> {
 
     let mut all_inputs: Libinput = Libinput::new_with_udev(Interface);
     all_inputs.udev_assign_seat("seat0").unwrap();   // will not throw an error on failure!
 
-    // Events added are dropped by the find() in the next statement, so they need to be 
+    // Events added are dropped by the find() in the next statement, so they need to be
     // counted beforehand. Cloning all_inputs and finding the length of the collected Vec
     // gave me issues as well, so we're sticking to a more tranparent, reliable method.
     let mut dev_added_count: u8 = 0;
-    
+
     // Libinput adds "touchpad" to the device you use for a trackpad.
     // This finds theat device among all active ones on your computer.
     let all_trackpads: Vec<input::Device> = all_inputs.filter(
         |event| {
             dev_added_count += 1;
-            event.device().has_capability(Pointer) 
+            event.device().has_capability(Pointer)
             && event.device().has_capability(Gesture)
             // virtual trackpad only has "pointer" capability,
             // so that will not be added here
@@ -205,9 +157,19 @@ pub fn find_real_trackpads() -> Result<Libinput, std::io::Error> {
     ).map(|event| event.device())
     .collect();
 
-    if all_trackpads.len() == 0 { 
-        return raise_correct_error(dev_added_count); 
+    if all_trackpads.len() == 0 {
+        return Err(raise_correct_error(dev_added_count));
     }
 
-    bind_to_real_trackpads(all_trackpads)
+    let paths: Vec<String> = all_trackpads.iter()
+        .map(|d| {
+            info!("A touchpad found and loaded.");
+            debug!("The touchpad device found: \"{}\" (udev path: /dev/input/{}).",
+                d.name(), d.sysname()
+            );
+            format!("/dev/input/{}", d.sysname())
+        })
+        .collect();
+
+    Ok(paths)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,14 @@ use std::{
 };
 use tokio::sync::mpsc::{self, Receiver};
 use signal_hook::{self, consts::{SIGINT, SIGTERM}, flag};
-use tracing::{debug, error, info, trace};
+use tracing::{debug, info, warn};
 use tracing_subscriber::fmt::time::ChronoLocal;
 
 use linux_3_finger_drag::{
     init::{config, libinput_init},
     runtime::{
-        event_handler::{ControlSignal, GestureTranslator, GtError}, 
+        event_handler::{ControlSignal, GestureTranslator, GtError},
+        mt_proxy::MtProxy,
         virtual_trackpad
     }
 };
@@ -20,13 +21,13 @@ use linux_3_finger_drag::{
 #[tokio::main]
 async fn main() -> Result<(), GtError> {
 
-    let cfg_file = config::get_config_file_path()?; 
+    let cfg_file = config::get_config_file_path()?;
     let cfg_last_modified = std::fs::metadata(cfg_file)?.modified()?;
 
     let configs = config::init_cfg();
 
     match config::init_file_logger(configs.clone()) {
-        Some(logger) => logger.init(), 
+        Some(logger) => logger.init(),
         None => {
             tracing_subscriber::fmt()
                 .with_writer(std::io::stdout)
@@ -35,7 +36,7 @@ async fn main() -> Result<(), GtError> {
                 .init();
         }
     };
-    println!("[PRE-LOG: INFO]: Logger initialized!"); 
+    println!("[PRE-LOG: INFO]: Logger initialized!");
 
     // handling SIGINT and SIGTERM
     let should_exit = Arc::new(AtomicBool::new(false));
@@ -47,50 +48,65 @@ async fn main() -> Result<(), GtError> {
 
     info!("Searching for the trackpad on your device...");
 
-    info!("end evdev search");
-    // using a match case here instead of a `?` here so the program can destruct 
+    // using a match case here instead of a `?` here so the program can destruct
     // the virtual trackpad before it exits
     let main_result = match libinput_init::find_real_trackpads() {
 
-        Ok(real_trackpad) => {
+        Ok(paths) if paths.is_empty() => {
+            Err(GtError::from(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "no trackpad paths returned"
+            )))
+        },
 
-            let translator = GestureTranslator::new(
-                vtrackpad.clone(), 
-                configs.clone(),
-                sender
-            );
-            run_main_event_loop(
-                translator, 
-                recvr, 
-                &should_exit, 
-                real_trackpad, 
-                cfg_last_modified
-            ).await
+        Ok(paths) => {
+
+            if paths.len() > 1 {
+                warn!("Found {} trackpads; only proxying the first one ({}).", paths.len(), paths[0]);
+            }
+
+            match MtProxy::new(&paths[0]) {
+                Ok(proxy) => {
+                    let translator = GestureTranslator::new(
+                        vtrackpad.clone(),
+                        configs.clone(),
+                        sender
+                    );
+                    run_main_event_loop(
+                        translator,
+                        recvr,
+                        &should_exit,
+                        proxy,
+                        cfg_last_modified
+                    ).await
+                },
+                Err(e) => Err(GtError::from(e))
+            }
         },
         Err(e) => Err(GtError::from(e))
     };
 
-    // the program arrives here if either a signal is received, 
+    // the program arrives here if either a signal is received,
     // or there was some issue during initialization
     info!("Cleaning up and exiting...");
     vtrackpad.mouse_up()?;      // just in case
     vtrackpad.destruct()?;      // we don't need virtual devices cluttering the system
-    
+
     info!("Clean up successful.");
     main_result
 }
 
 
-// This function is placed in `main.rs` since it's essentially a 
+// This function is placed in `main.rs` since it's essentially a
 // part of `main`, and I wanted to break it out so the `main` isn't
 // too sprawling
 async fn run_main_event_loop(
     mut translator: GestureTranslator,
     recvr: Receiver<ControlSignal>,
     should_exit: &Arc<AtomicBool>,
-    mut real_trackpad: input::Libinput, 
+    mut proxy: MtProxy,
     mut cfg_last_modified: SystemTime
-    
+
 ) -> Result<(), GtError> {
 
     // spawn 1 separate thread to handle mouse_up_delay timeouts
@@ -105,7 +121,7 @@ async fn run_main_event_loop(
     };
 
     let mouse_up_listener = tokio::spawn(fork_fn);
-    let cfg_file_path = config::get_config_file_path()?; 
+    let cfg_file_path = config::get_config_file_path()?;
 
     info!("linux-3-finger-drag started successfully!");
 
@@ -124,47 +140,22 @@ async fn run_main_event_loop(
 
             cfg_last_modified = cfg_last_modified_update;
         }
-        
-        // check if the configuration was modified, and if so, update configs in memory
-        let cfg_last_modified_update = std::fs::metadata(&cfg_file_path)?.modified()?;
-
-        if cfg_last_modified_update > cfg_last_modified {
-
-            let new_cfg = config::init_cfg();
-            translator.cfg = new_cfg.clone();
-
-            cfg_last_modified = cfg_last_modified_update;
-        }
-
 
         // handle interrupts
         if should_exit.load(Ordering::Relaxed) {
             break;
         }
-        
-        if let Err(e) = real_trackpad.dispatch() {
-            error!("A {} error occured in reading device buffer: {}", e.kind(), e);
-        }
 
-        for event in &mut real_trackpad {
+        proxy.poll(&mut translator).await?;
 
-            trace!("Blocking in main()'s for loop");
-
-            // do nothing on success (or ignored gesture)
-            if let Err(e) = translator.translate_gesture(event).await { 
-                error!("{:?}", e); 
-            }
-
-            // Without being a `ControlSignal::TerminateThread` being sent
-            // into the channel, the other thread only finishes when
-            // is an error is raised. it has been designed not to panic. 
-            // the value the thread returns is a `Result`, so the this extracts 
-            // the Result from the fork and returns it.
-            if mouse_up_listener.is_finished() {
-                let fork_err = mouse_up_listener.await?.unwrap_err();
-                error!("Error raised in fork: {:?}", fork_err);
-                return Err(fork_err);
-            }
+        // Without being a `ControlSignal::TerminateThread` being sent
+        // into the channel, the other thread only finishes when
+        // is an error is raised. it has been designed not to panic.
+        // the value the thread returns is a `Result`, so the this extracts
+        // the Result from the fork and returns it.
+        if mouse_up_listener.is_finished() {
+            let fork_err = mouse_up_listener.await?.unwrap_err();
+            return Err(fork_err);
         }
     };
 
@@ -172,7 +163,7 @@ async fn run_main_event_loop(
     translator.send_signal(ControlSignal::TerminateThread).await?;
 
     // awaiting a JoinHandle produces a Result
-    // the generic for this JoinHandle, though, is itself a Result, 
+    // the generic for this JoinHandle, though, is itself a Result,
     // so we can just return what the JoinHandle yields
-    mouse_up_listener.await? 
+    mouse_up_listener.await?
 }

--- a/src/runtime/event_handler.rs
+++ b/src/runtime/event_handler.rs
@@ -2,20 +2,8 @@ use std::time::Duration;
 
 //use smol::{channel::{RecvError, SendError, Sender}};
 use tokio::sync::mpsc::{error::SendError, Sender};
-use input::{
-    event::{
-        gesture::{
-            GestureEvent, 
-            GestureEventCoordinates, 
-            GestureEventTrait, 
-            GestureHoldEvent, 
-            GestureSwipeEvent
-        }
-    }, Event
-};
 
-
-use tracing::{debug, trace};
+use tracing::trace;
 
 use super::virtual_trackpad::VirtualTrackpad;
 use super::super::init::config::Configuration;
@@ -24,13 +12,13 @@ use super::super::init::config::Configuration;
 /// of the listener on the separate thread that controls
 /// when the mouse hold is released. Here's what each signal
 /// means in more detail:
-/// 
+///
 /// `CancelTimer`: Cancel the timer, and release drag inside fork
-/// 
+///
 /// `CancelMouseUp`: Cancel timer, and don't do anything else in the fork (await next signal)
-/// 
+///
 /// `RestartTimer`: Restart timer by restarting the loop in the fork that starts with a timer
-/// 
+///
 /// `TerminateThread`: Terminate function running in fork
 #[derive(Debug)]
 pub enum ControlSignal {
@@ -66,10 +54,14 @@ impl From<SendError<ControlSignal>> for GtError {
 
     fn from(err: SendError<ControlSignal>) -> Self {
         GtError::ChannelSendError(err)
-    } 
+    }
 }
 
 
+/// Drives the drag emulation (the virtual mouse). Gesture *detection* now
+/// lives in `mt_proxy`, which owns the real trackpad and decides when a
+/// 3-finger sequence begins/moves/ends; this struct just carries out the
+/// resulting mouse_down/move/up primitives, same as before.
 pub struct GestureTranslator {
     pub vtp: VirtualTrackpad,
     pub cfg: Configuration,
@@ -77,10 +69,10 @@ pub struct GestureTranslator {
 }
 
 impl GestureTranslator {
-    
+
     pub fn new(
-        vtp: VirtualTrackpad, 
-        cfg: Configuration, 
+        vtp: VirtualTrackpad,
+        cfg: Configuration,
         tx: Sender<ControlSignal>
     ) -> GestureTranslator {
 
@@ -92,7 +84,7 @@ impl GestureTranslator {
     }
 
 
-    async fn update_cursor_position(&mut self, dx: f64, dy: f64) -> Result<(), GtError> {
+    pub(crate) async fn update_cursor_position(&mut self, dx: f64, dy: f64) -> Result<(), GtError> {
 
         trace!("Moving cursor...");
         // if the cursor is moving during a drag, we don't want
@@ -100,85 +92,35 @@ impl GestureTranslator {
         self.send_signal(ControlSignal::CancelMouseUp).await?;
 
         self.vtp.mouse_move_relative(
-            dx * self.cfg.acceleration, 
+            dx * self.cfg.acceleration,
             dy * self.cfg.acceleration
         )?;
 
         Ok(())
     }
 
-    
-    pub async fn translate_gesture(&mut self, event: Event) -> Result<(), GtError> {
-    
-        debug!("Event received: {:?}", event);
-
-        match event {
-            Event::Gesture(gest_ev) => {
-
-                // we don't care about gestures with other finger-counts
-                if gest_ev.finger_count() != 3 {
-                    debug!("Gesture not three-fingered, releasing drag");
-                    return self.mouse_up_now().await;
-                }
-            
-                match gest_ev {
-
-                    GestureEvent::Hold(gest_hold_ev) => self.handle_hold(gest_hold_ev).await,
-                    GestureEvent::Swipe(swipe_ev) => self.handle_swipe(swipe_ev).await,
-                    _ => self.mouse_up_now().await // just in case, so the drag isn't locked
-                }
-            },
-            _ => self.mouse_up_now().await
-        }
-    }
-
-
-    async fn handle_hold(&mut self, hold_ev: GestureHoldEvent) -> Result<(), GtError> {
-        match hold_ev {
-            GestureHoldEvent::Begin(_) => self.mouse_down().await,
-            GestureHoldEvent::End(_)   => self.handle_mouse_up().await,
-            _ => self.mouse_up_now().await
-        }
-    }
-
-
-    async fn handle_swipe(&mut self, swipe_ev: GestureSwipeEvent) -> Result<(), GtError> {
-                    
-        match swipe_ev {
-            GestureSwipeEvent::Update(swipe_update) => {            
-                self.update_cursor_position(
-                    swipe_update.dx(), 
-                    swipe_update.dy()
-                ).await
-            }
-            GestureSwipeEvent::Begin(_) => self.mouse_down().await,
-            GestureSwipeEvent::End(_)   => self.handle_mouse_up().await,
-            _ => self.mouse_up_now().await
-        }
-    }
-
 
     /// Sets mouse to down immediately, and cancels background
     /// `mouse_up_delay` timer.
-    async fn mouse_down(&mut self) -> Result<(), GtError> {
-        
+    pub(crate) async fn mouse_down(&mut self) -> Result<(), GtError> {
+
         self.send_signal(ControlSignal::CancelMouseUp).await?;
-        
+
         self.vtp
             .mouse_down()
             .map_err(GtError::from)
     }
 
 
-    /// Handles the logic of calling the right function for 
+    /// Handles the logic of calling the right function for
     /// releasing the mouse down state, to simplify functions
     /// further up the call stack.
-    async fn handle_mouse_up(&mut self) -> Result<(), GtError> {
+    pub(crate) async fn handle_mouse_up(&mut self) -> Result<(), GtError> {
 
         // don't bother with forking and all that if there is
         // no delay to begin with
         if self.cfg.drag_end_delay == Duration::ZERO {
-            
+
             return self.mouse_up_now().await;
         }
 
@@ -188,9 +130,9 @@ impl GestureTranslator {
 
 
     /// Cancels the drag, cutting off any currently running delay.
-    /// The left click is released here, not in the fork when the 
+    /// The left click is released here, not in the fork when the
     /// timer is running to cut down on latency.
-    async fn mouse_up_now(&mut self) -> Result<(), GtError> {
+    pub(crate) async fn mouse_up_now(&mut self) -> Result<(), GtError> {
         trace!("Cancelling timer, ending drag immediately");
         self.send_signal(ControlSignal::CancelMouseUp).await?;
         Ok(self.vtp.mouse_up()?)
@@ -199,8 +141,8 @@ impl GestureTranslator {
 
     /// Wrapper to send signal into channel.
     pub async fn send_signal(&mut self, sig: ControlSignal) -> Result<(), GtError> {
-        
-        // The channel can only hold a few messages (I chose to give it a 
+
+        // The channel can only hold a few messages (I chose to give it a
         // low bound), and this send will block until there is space in the
         // channel.
         trace!("Sending signal: {:?}", sig);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3,4 +3,5 @@
 // during initialization, but the rest
 // here is used in runtime only.
 pub mod event_handler;
+pub mod mt_proxy;
 pub mod virtual_trackpad;

--- a/src/runtime/mt_proxy.rs
+++ b/src/runtime/mt_proxy.rs
@@ -1,0 +1,358 @@
+// Proxies the real touchpad's raw multitouch stream to a synthetic clone
+// device, 1:1, EXCEPT while exactly 3 fingers are touching: that window is
+// withheld from the clone entirely (never begun, never left half-open) and
+// instead drives the existing 3-finger-drag emulation on the virtual mouse.
+//
+// This exists because a naive mid-gesture EVIOCGRAB on the real device (this
+// project's first approach) leaves the compositor's own touch-state tracking
+// permanently corrupted: the compositor never gets to see the closing
+// lift-off frames for the fingers grabbed away mid-gesture, so it's stuck
+// believing they're still down. By instead owning the real device for the
+// program's entire lifetime and re-emitting a clean copy of it, we control
+// every frame the compositor ever sees: either an accurate mirror of the
+// real pad, or an explicit "nothing is touching" state we emit ourselves --
+// never a silent gap.
+
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::os::unix::fs::OpenOptionsExt;
+
+use nix::libc::O_NONBLOCK;
+use tracing::{debug, info, trace, warn};
+
+use input_linux::{sys, AbsoluteAxis, AbsoluteInfoSetup, EvdevHandle, EventKind, InputId, UInputHandle};
+
+use super::event_handler::{GestureTranslator, GtError};
+
+const EV_SYN: u16 = 0x00;
+const EV_ABS: u16 = 0x03;
+const SYN_REPORT: u16 = 0x00;
+const SYN_DROPPED: u16 = 0x03;
+const ABS_MT_SLOT: u16 = 0x2f;
+const ABS_MT_TRACKING_ID: u16 = 0x39;
+const ABS_MT_POSITION_X: u16 = 0x35;
+const ABS_MT_POSITION_Y: u16 = 0x36;
+
+const MAX_SLOTS: usize = 16;
+const READ_BATCH: usize = 64;
+
+// Empirically-reasonable px-per-mm scale for turning the real finger delta
+// into cursor movement; this combines with the existing `acceleration`
+// config knob, so it doesn't need to be exact -- just a sane starting point.
+const PX_PER_MM: f64 = 4.0;
+
+#[derive(Clone, Copy)]
+struct Slot {
+    tracking_id: i32,
+    x: i32,
+    y: i32,
+}
+
+impl Default for Slot {
+    fn default() -> Self {
+        Slot { tracking_id: -1, x: 0, y: 0 }
+    }
+}
+
+fn zero_event() -> sys::input_event {
+    unsafe { std::mem::zeroed() }
+}
+
+fn abs_event(code: u16, value: i32) -> sys::input_event {
+    let mut ev = zero_event();
+    ev.type_ = EV_ABS;
+    ev.code = code;
+    ev.value = value;
+    ev
+}
+
+fn syn_report() -> sys::input_event {
+    let mut ev = zero_event();
+    ev.type_ = EV_SYN;
+    ev.code = SYN_REPORT;
+    ev.value = 0;
+    ev
+}
+
+pub struct MtProxy {
+    real: EvdevHandle<File>,
+    synth: UInputHandle<File>,
+    x_res: f64,
+    y_res: f64,
+    slots: [Slot; MAX_SLOTS],
+    current_slot: usize,
+    relayed_active: [bool; MAX_SLOTS],
+    suppressing: bool,
+    drag_ref_slot: Option<usize>,
+    drag_last_pos: Option<(i32, i32)>,
+    frame: Vec<sys::input_event>,
+    read_buf: [sys::input_event; READ_BATCH],
+}
+
+impl MtProxy {
+    /// Opens the real touchpad at `path`, grabs it exclusively for the rest
+    /// of the program's life, and creates a synthetic clone with the same
+    /// multitouch capabilities for the compositor to read instead.
+    pub fn new(path: &str) -> io::Result<Self> {
+        let real_file = OpenOptions::new()
+            .read(true)
+            .custom_flags(O_NONBLOCK)
+            .open(path)?;
+        let real = EvdevHandle::new(real_file);
+
+        // held for the entire program lifetime -- see module doc for why
+        // this must never be released mid-gesture.
+        real.grab(true)?;
+        info!("Exclusively grabbed the real trackpad at {}.", path);
+
+        let synth = Self::clone_device(&real)?;
+
+        let x_res = real.absolute_info(AbsoluteAxis::MultitouchPositionX)
+            .map(|i| i.resolution.max(1) as f64)
+            .unwrap_or(1.0);
+        let y_res = real.absolute_info(AbsoluteAxis::MultitouchPositionY)
+            .map(|i| i.resolution.max(1) as f64)
+            .unwrap_or(1.0);
+
+        Ok(MtProxy {
+            real,
+            synth,
+            x_res,
+            y_res,
+            slots: [Slot::default(); MAX_SLOTS],
+            current_slot: 0,
+            relayed_active: [false; MAX_SLOTS],
+            suppressing: false,
+            drag_ref_slot: None,
+            drag_last_pos: None,
+            frame: Vec::with_capacity(READ_BATCH),
+            read_buf: [zero_event(); READ_BATCH],
+        })
+    }
+
+    /// Builds a synthetic uinput device with the same EV_KEY/EV_ABS/
+    /// INPUT_PROP capabilities as the real device, so the compositor's own
+    /// libinput sees something functionally identical to the real hardware.
+    fn clone_device(real: &EvdevHandle<File>) -> io::Result<UInputHandle<File>> {
+        let uinput_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .custom_flags(O_NONBLOCK)
+            .open("/dev/uinput")?;
+        let synth = UInputHandle::new(uinput_file);
+
+        synth.set_evbit(EventKind::Key)?;
+        synth.set_evbit(EventKind::Absolute)?;
+
+        for key in real.key_bits()?.iter() {
+            synth.set_keybit(key)?;
+        }
+
+        let mut abs_setups = Vec::new();
+        for axis in real.absolute_bits()?.iter() {
+            synth.set_absbit(axis)?;
+            let info = real.absolute_info(axis)?;
+            abs_setups.push(AbsoluteInfoSetup { axis, info });
+        }
+
+        for prop in real.device_properties()?.iter() {
+            synth.set_propbit(prop)?;
+        }
+
+        let input_id = InputId {
+            bustype: input_linux::sys::BUS_USB,
+            vendor: 0x1234,
+            product: 0x5679, // distinct from the drag-emulation mouse's 0x5678
+            version: 0,
+        };
+        let device_name = b"Virtual touchpad (proxied by linux-3-finger-drag)";
+        synth.create(&input_id, device_name, 0, &abs_setups)?;
+        debug!("Synthetic touchpad clone created.");
+
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        Ok(synth)
+    }
+
+    /// One non-blocking pass: drains whatever raw events are currently
+    /// available, processing them frame-by-frame (a frame being everything
+    /// since the last SYN_REPORT). Safe to call frequently in a poll loop.
+    pub async fn poll(&mut self, translator: &mut GestureTranslator) -> Result<(), GtError> {
+        loop {
+            let n = match self.real.read(&mut self.read_buf) {
+                Ok(n) => n,
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+                Err(e) => return Err(GtError::from(e)),
+            };
+
+            if n == 0 {
+                return Ok(());
+            }
+
+            for i in 0..n {
+                let ev = self.read_buf[i];
+
+                if ev.type_ == EV_SYN && ev.code == SYN_DROPPED {
+                    warn!("Kernel reported dropped events; resyncing slot state.");
+                    self.frame.clear();
+                    self.resync()?;
+                    continue;
+                }
+
+                if ev.type_ == EV_SYN && ev.code == SYN_REPORT {
+                    self.frame.push(ev);
+                    self.handle_frame(translator).await?;
+                    self.frame.clear();
+                    continue;
+                }
+
+                if ev.type_ == EV_ABS && ev.code == ABS_MT_SLOT {
+                    self.current_slot = (ev.value as usize).min(MAX_SLOTS - 1);
+                } else if ev.type_ == EV_ABS && ev.code == ABS_MT_TRACKING_ID {
+                    self.slots[self.current_slot].tracking_id = ev.value;
+                } else if ev.type_ == EV_ABS && ev.code == ABS_MT_POSITION_X {
+                    self.slots[self.current_slot].x = ev.value;
+                } else if ev.type_ == EV_ABS && ev.code == ABS_MT_POSITION_Y {
+                    self.slots[self.current_slot].y = ev.value;
+                }
+
+                self.frame.push(ev);
+            }
+        }
+    }
+
+    /// Re-derives slot state directly from the kernel (EVIOCGMTSLOTS)
+    /// instead of trusting the incremental event history, used after a
+    /// SYN_DROPPED. Forces a full resync dump to the synthetic device
+    /// afterward, same as any other suppress/passthrough transition.
+    fn resync(&mut self) -> Result<(), GtError> {
+        let mut ids = vec![0i32; MAX_SLOTS];
+        self.real.multi_touch_slots(AbsoluteAxis::MultitouchTrackingId, &mut ids)?;
+
+        let mut xs = vec![0i32; MAX_SLOTS];
+        self.real.multi_touch_slots(AbsoluteAxis::MultitouchPositionX, &mut xs)?;
+
+        let mut ys = vec![0i32; MAX_SLOTS];
+        self.real.multi_touch_slots(AbsoluteAxis::MultitouchPositionY, &mut ys)?;
+
+        for slot in 0..MAX_SLOTS {
+            self.slots[slot] = Slot { tracking_id: ids[slot], x: xs[slot], y: ys[slot] };
+        }
+
+        // don't decide suppress/passthrough here; the next real frame will
+        // trigger handle_frame() and pick correctly based on active_count
+        Ok(())
+    }
+
+    fn active_slots(&self) -> Vec<usize> {
+        (0..MAX_SLOTS).filter(|&s| self.slots[s].tracking_id >= 0).collect()
+    }
+
+    async fn handle_frame(&mut self, translator: &mut GestureTranslator) -> Result<(), GtError> {
+        let active = self.active_slots();
+
+        if active.len() == 3 {
+            if !self.suppressing {
+                self.enter_suppress()?;
+                translator.mouse_down().await?;
+            }
+            self.drive_drag(&active, translator).await?;
+            // frame intentionally not relayed
+            return Ok(());
+        }
+
+        if self.suppressing {
+            self.suppressing = false;
+            self.drag_ref_slot = None;
+            self.drag_last_pos = None;
+            translator.handle_mouse_up().await?;
+            self.resync_synth_to_real()?;
+            // the resync dump above already reflects this frame's true
+            // state, so the raw frame itself doesn't also need relaying
+            return Ok(());
+        }
+
+        self.relay_frame()
+    }
+
+    fn enter_suppress(&mut self) -> Result<(), GtError> {
+        self.suppressing = true;
+
+        let mut release_frame = Vec::new();
+        for slot in 0..MAX_SLOTS {
+            if self.relayed_active[slot] {
+                release_frame.push(abs_event(ABS_MT_SLOT, slot as i32));
+                release_frame.push(abs_event(ABS_MT_TRACKING_ID, -1));
+                self.relayed_active[slot] = false;
+            }
+        }
+        if !release_frame.is_empty() {
+            release_frame.push(syn_report());
+            self.synth.write(&release_frame)?;
+            trace!("Released all relayed slots to the synthetic device before suppressing.");
+        }
+        Ok(())
+    }
+
+    async fn drive_drag(&mut self, active: &[usize], translator: &mut GestureTranslator) -> Result<(), GtError> {
+        let reference = match self.drag_ref_slot {
+            Some(s) if active.contains(&s) => s,
+            _ => {
+                // first frame of the gesture, or our previous reference
+                // finger lifted and a different one took its place:
+                // re-baseline without applying a delta this frame.
+                let s = active[0];
+                self.drag_ref_slot = Some(s);
+                self.drag_last_pos = Some((self.slots[s].x, self.slots[s].y));
+                return Ok(());
+            }
+        };
+
+        let (x, y) = (self.slots[reference].x, self.slots[reference].y);
+        if let Some((lx, ly)) = self.drag_last_pos {
+            let dx_mm = (x - lx) as f64 / self.x_res;
+            let dy_mm = (y - ly) as f64 / self.y_res;
+            translator.update_cursor_position(dx_mm * PX_PER_MM, dy_mm * PX_PER_MM).await?;
+        }
+        self.drag_last_pos = Some((x, y));
+        Ok(())
+    }
+
+    /// Dumps the current real slot state to the synthetic device as a
+    /// coherent, self-contained frame -- used when leaving suppression, so
+    /// the compositor gets an accurate picture regardless of which fields
+    /// happened to change in the triggering frame.
+    fn resync_synth_to_real(&mut self) -> Result<(), GtError> {
+        let mut dump = Vec::new();
+        for slot in 0..MAX_SLOTS {
+            let s = self.slots[slot];
+            let active = s.tracking_id >= 0;
+            if active || self.relayed_active[slot] {
+                dump.push(abs_event(ABS_MT_SLOT, slot as i32));
+                dump.push(abs_event(ABS_MT_TRACKING_ID, s.tracking_id));
+                if active {
+                    dump.push(abs_event(ABS_MT_POSITION_X, s.x));
+                    dump.push(abs_event(ABS_MT_POSITION_Y, s.y));
+                }
+                self.relayed_active[slot] = active;
+            }
+        }
+        if !dump.is_empty() {
+            dump.push(syn_report());
+            self.synth.write(&dump)?;
+            trace!("Resynced synthetic device to current real slot state.");
+        }
+        Ok(())
+    }
+
+    fn relay_frame(&mut self) -> Result<(), GtError> {
+        if self.frame.is_empty() {
+            return Ok(());
+        }
+        for slot in self.active_slots() {
+            self.relayed_active[slot] = true;
+        }
+        self.synth.write(&self.frame)?;
+        Ok(())
+    }
+}

--- a/src/runtime/mt_proxy.rs
+++ b/src/runtime/mt_proxy.rs
@@ -36,10 +36,10 @@ const ABS_MT_POSITION_Y: u16 = 0x36;
 const MAX_SLOTS: usize = 16;
 const READ_BATCH: usize = 64;
 
-// Empirically-reasonable px-per-mm scale for turning the real finger delta
-// into cursor movement; this combines with the existing `acceleration`
-// config knob, so it doesn't need to be exact -- just a sane starting point.
-const PX_PER_MM: f64 = 4.0;
+// px-per-mm scale for turning the real finger delta into cursor movement;
+// combines with the `acceleration` config knob on top. 12.0 (4.0 x the
+// initial guess) is the value the user confirmed feels right live.
+const PX_PER_MM: f64 = 12.0;
 
 #[derive(Clone, Copy)]
 struct Slot {


### PR DESCRIPTION
Closes #18.

## The conflict

KWin (KDE's compositor) hardcodes a 3-finger horizontal swipe as an
*alternate* binding for its virtual-desktop-switch gesture, alongside the
usual 4-finger one (confirmed by reading KWin's source,
`src/virtualdesktops.cpp`):

```cpp
input()->registerTouchpadSwipeShortcut(SwipeDirection::Left, 3, ...);
input()->registerTouchpadSwipeShortcut(SwipeDirection::Right, 3, ...);
input()->registerTouchpadSwipeShortcut(SwipeDirection::Left, 4, ...);
input()->registerTouchpadSwipeShortcut(SwipeDirection::Right, 4, ...);
```

This isn't user-configurable, and it directly competes with this program:
both this program and the compositor's own libinput instance read the
identical raw 3-finger swipe from the touchpad and act on it independently,
since the touchpad was never exclusively grabbed. Reported in #18 on
CachyOS/KDE Plasma 6 (Wayland).

## First attempt (didn't work out)

My first fix grabbed the real device only for the duration of a 3-finger
gesture (`EVIOCGRAB` on begin, release on end). That does stop the
desktop-switch, but it breaks the touchpad afterward: the compositor's own
libinput instance never gets to see the *lift-off* events for the fingers
grabbed away mid-gesture (a grab only delivers events to the fd holding it),
so its multitouch slot-tracking gets stuck believing fingers are still down.
The next real touch then gets merged into that stale state, which froze the
cursor and occasionally misfired KWin's pinch-to-zoom gesture. Raw evdev
touch reporting is fundamentally not something you can partially/temporarily
hide from one reader without corrupting its state.

## This PR's approach

Grab the real touchpad exclusively for the program's entire lifetime
instead, and proxy it:

- Opens the real device via raw evdev (`EvdevHandle`, not through libinput)
  and grabs it once at startup, permanently.
- Creates a synthetic uinput device that clones the real touchpad's exact
  `EV_KEY`/`EV_ABS`/`INPUT_PROP` capabilities (verified byte-identical
  against `/proc/bus/input/devices`, and correctly tagged
  `ID_INPUT_TOUCHPAD=1` by udev, same as the real device).
- Every raw frame (batched per `SYN_REPORT`) is relayed to the synthetic
  device unchanged, *unless* exactly 3 fingers are active — in which case
  the frame is withheld and the reference-finger delta drives the existing
  virtual-mouse drag emulation instead, same as before.
- On entering suppression, any slots currently relayed to the synthetic
  device are explicitly released first (a clean lift-off, not a stall). On
  leaving suppression, the synthetic device gets a fresh, self-contained
  dump of the real device's current slot state (via the internal slot
  tracking this proxy already maintains), rather than relying on whichever
  fields happened to change in the triggering frame. A `SYN_DROPPED` from
  the kernel triggers the same resync via `EVIOCGMTSLOTS`.

Net effect: the compositor only ever sees either an accurate mirror of the
real touchpad, or an explicit "nothing is touching" state it was told about
— never a silent gap with stale slot state. 1/2/4/5-finger interactions are
byte-identical passthrough and behave exactly as before (I use 2-finger
scroll and 4-finger desktop-switch daily and both are unaffected); only the
3-finger case is ever touched.

One side effect: gesture detection no longer goes through libinput's
`Gesture` event layer, since touchpads don't expose raw per-slot data
through that API (only the interpreted pointer/scroll/gesture events) —
which is exactly what this proxy needs for the passthrough side. libinput is
now only used for the initial device-discovery pass, matching by capability
same as before.

## Testing

Tested live on the reporting machine (MacBookPro11,3, CachyOS, KDE Plasma 6
Wayland, `bcm5974` touchpad) across multiple sessions: 3-finger drag no
longer triggers desktop switching, 4-finger swipe still switches desktops
correctly, and — importantly, since it's what broke the first attempt —
normal 1-finger cursor movement and 2-finger scroll remain fully functional
immediately after a 3-finger drag, with no freeze or stray gesture misfires.

Happy to adjust anything — this is a fairly different internal architecture
than the current libinput-gesture-based one, so I understand if you want
changes before merging.